### PR TITLE
Fix: Allow multi-char atom symbols in Z-matrix

### DIFF
--- a/automol/tests/test_zmat.py
+++ b/automol/tests/test_zmat.py
@@ -6,6 +6,21 @@ import numpy
 from automol import zmat, geom, smiles
 
 H_ZMA = geom.zmatrix(smiles.geometry('[H]'))
+C4H9Cl_ZMA = (
+    ('C', (None, None, None), (None, None, None), (None, None, None)),
+    ('C', (0, None, None), ('R1', None, None), (2.874139, None, None)),
+    ('H', (0, 1, None), ('R2', 'A2', None), (2.068404, 1.938152, None)),
+    ('H', (0, 1, 2), ('R3', 'A3', 'D3'), (2.067124, 1.946485, 2.113923)),
+    ('H', (0, 1, 2), ('R4', 'A4', 'D4'), (2.068836, 1.920692, 4.19662)),
+    ('C', (1, 0, 2), ('R5', 'A5', 'D5'), (2.891871, 1.980869, 5.320083)),
+    ('H', (1, 0, 5), ('R6', 'A6', 'D6'), (2.072228, 1.893902, 2.105771)),
+    ('H', (1, 0, 5), ('R7', 'A7', 'D7'), (2.071582, 1.910024, 4.133631)),
+    ('C', (5, 1, 0), ('R8', 'A8', 'D8'), (2.879211, 1.973247, 5.14005)),
+    ('H', (5, 1, 8), ('R9', 'A9', 'D9'), (2.073196, 1.910352, 2.052359)),
+    ('H', (5, 1, 8), ('R10', 'A10', 'D10'), (2.07375, 1.886055, 4.168646)),
+    ('Cl', (8, 5, 1), ('R11', 'A11', 'D11'), (3.364415, 1.925124, 3.054326)),
+    ('H', (8, 5, 11), ('R12', 'A12', 'D12'), (2.067368, 1.940624, 2.089928)),
+    ('H', (8, 5, 11), ('R13', 'A13', 'D13'), (2.065645, 1.94931, 4.356739)))
 CH4O2_ZMA = (
     ('C', (None, None, None), (None, None, None), (None, None, None)),
     ('O', (0, None, None), ('R1', None, None), (2.659, None, None)),
@@ -438,6 +453,11 @@ def test__string():
 
     # Make sure we can handle monatomics correctly
     assert H_ZMA == zmat.from_string(zmat.string(H_ZMA))
+
+    # Make sure we can parse Z-matrics with multi-character atom symbols
+    # (This was broken)
+    zma = zmat.from_string(zmat.string(C4H9Cl_ZMA))
+    assert zmat.almost_equal(zma, C4H9Cl_ZMA)
 
 
 def test__coord_values():

--- a/automol/vmat.py
+++ b/automol/vmat.py
@@ -17,10 +17,10 @@ SYMBOL = pp.Combine(CHAR + pp.Opt(CHAR))
 VNAME = pp.Combine(pp.Word(pp.alphas) + pp.Opt(pp.Word(pp.nums)))
 LINE_END = pp.Suppress(pp.lineEnd())
 
-LINE0 = pp.Group(CHAR)
-LINE1 = pp.Group(CHAR + ppc.integer + VNAME)
-LINE2 = pp.Group(CHAR + (ppc.integer + VNAME) * 2)
-LINE3 = pp.Group(CHAR + (ppc.integer + VNAME) * 3)
+LINE0 = pp.Group(SYMBOL)
+LINE1 = pp.Group(SYMBOL + ppc.integer + VNAME)
+LINE2 = pp.Group(SYMBOL + (ppc.integer + VNAME) * 2)
+LINE3 = pp.Group(SYMBOL + (ppc.integer + VNAME) * 3)
 
 LINES0 = LINE0
 LINES1 = LINE0 + LINE_END + LINE1


### PR DESCRIPTION
A bug in the Z-matrix parser was requiring a single character for the atom symbol