### PR TITLE
Fix: Z-matrix building with spiro atoms

### DIFF
--- a/automol/graph/__init__.py
+++ b/automol/graph/__init__.py
@@ -227,7 +227,7 @@ from automol.graph.base._02algo import (
     sorted_ring_atom_keys,
     sorted_ring_atom_keys_from_bond_keys,
     spiro_atom_keys,
-    spiro_atoms_grouped_neighbor_keys,
+    spiros,
     subgraph_isomorphism,
     unique,
 )
@@ -551,7 +551,7 @@ __all__ = [
     "ring_systems",
     "ring_systems_atom_keys",
     "ring_systems_bond_keys",
-    "spiro_atoms_grouped_neighbor_keys",
+    "spiros",
     "spiro_atom_keys",
     "is_ring_system",
     "ring_system_decomposed_atom_keys",

--- a/automol/graph/base/__init__.py
+++ b/automol/graph/base/__init__.py
@@ -208,7 +208,7 @@ from automol.graph.base._02algo import ring_arc_complement_atom_keys
 from automol.graph.base._02algo import ring_systems
 from automol.graph.base._02algo import ring_systems_atom_keys
 from automol.graph.base._02algo import ring_systems_bond_keys
-from automol.graph.base._02algo import spiro_atoms_grouped_neighbor_keys
+from automol.graph.base._02algo import spiros
 from automol.graph.base._02algo import spiro_atom_keys
 from automol.graph.base._02algo import is_ring_system
 from automol.graph.base._02algo import ring_system_decomposed_atom_keys
@@ -535,7 +535,7 @@ __all__ = [
     "ring_systems",
     "ring_systems_atom_keys",
     "ring_systems_bond_keys",
-    "spiro_atoms_grouped_neighbor_keys",
+    "spiros",
     "spiro_atom_keys",
     "is_ring_system",
     "ring_system_decomposed_atom_keys",

--- a/automol/tests/test_reac.py
+++ b/automol/tests/test_reac.py
@@ -337,6 +337,9 @@ def test__end_to_end():
     # ring-forming scission (FIXED)
     _test(["[CH2]CCCOO"], ["C1CCCO1", "[OH]"])
     _test([r"[CH2]/C=C\[C@@H](CC)OO"], ["CC[C@H]1OCC=C1", "[OH]"])
+    # ring-forming scission with spiro atoms
+    _test(["CC1[C](O1)COO"], ["CC1C2(O1)CO2", "[OH]"])
+    _test(["CC1[C](OC1)CCOO"], ["CC1C2(OC1)CCO2", "[OH]"])
     # elimination
     _test(["CCCCO[O]"], ["CCC=C", "O[O]"])
     # elimination (HONO)


### PR DESCRIPTION
These were not being correctly handled by my ring-system arc-decomposition procedure for defining the z-matrix, but now they are.