### PR TITLE
Fix: InChIs w/ unperceived stereo can be complete

### DIFF
--- a/automol/inchi/_conv.py
+++ b/automol/inchi/_conv.py
@@ -161,12 +161,13 @@ def is_complete(ich):
     :type ich: str
     :rtype: bool
     """
-    gra = graph(ich, stereo=False)
-    is_missing_stereo = bool(graph_.unassigned_stereocenter_keys(gra))
+    gra0 = graph(ich, stereo=False)
 
-    return equivalent(ich, standard_form(ich)) and not (
-        has_stereo(ich) ^ is_missing_stereo
-    )
+    needs_stereo = False
+    if bool(graph_.unassigned_stereocenter_keys(gra0)):
+        needs_stereo = not has_stereo(ich)
+
+    return equivalent(ich, standard_form(ich)) and not needs_stereo
 
 
 def is_bad(ich, gra=None):

--- a/automol/tests/test_chi.py
+++ b/automol/tests/test_chi.py
@@ -400,6 +400,13 @@ def test__racemic():
     assert chi.racemic(C8H13O_ICH_NO_STEREO) == C8H13O_ICH_NO_STEREO
 
 
+def test__is_complete():
+    """ test inchi.is_complete
+    """
+    ich = 'InChI=1S/C4H6O2/c1-3-4(2,5-3)6-3/h1-2H3/t3-,4+'
+    assert chi.is_complete(ich)
+
+
 if __name__ == '__main__':
     # test__from_data()
     # test__formula_string()
@@ -421,3 +428,4 @@ if __name__ == '__main__':
     # test__join()
     # test__canonical_enantiomer()
     # test__racemic()
+    test__is_complete()


### PR DESCRIPTION
In topologically symmetric molecules like the following, AMChI is currently unable to recognize the two carbon atoms as stereogenic.

```
	  O
	 / \
   CH3--C---C--CH3
	 \ /
	  O
```

In these cases, InChI contains stereochemistry that AMChI does not, so the InChI should be treated as complete.