### PR TITLE
Allow for None value during geometry embedding

### DIFF
--- a/automol/graph/_0embed.py
+++ b/automol/graph/_0embed.py
@@ -92,6 +92,9 @@ def clean_geometry(
     :param relax_angles: Relax the angles in `geos`?
     :returns: The cleaned-up geometry
     """
+    if geo is None:
+        return None
+
     hard_geo = hardcoded_geometry(gra)
     if hard_geo is not None:
         return hard_geo
@@ -161,6 +164,9 @@ def geometry_matches(
     :returns: `True` if it does, `False` if it doesn't
     :rtype: bool
     """
+    if geo is None:
+        return False
+
     cgra = without_stereo(gra)
     cgra0 = geom.graph_without_stereo(geo, fix_hyper=False)
 

--- a/automol/graph/_2conv.py
+++ b/automol/graph/_2conv.py
@@ -582,6 +582,9 @@ def perturb_geometry_planar_dihedrals(
         given amount
     :rtype: automol geometry data structure
     """
+    if geo is None:
+        return None
+
     ang = ang * phycon.DEG2RAD if degree else ang
 
     # Align the graph and the geometry keys/indices

--- a/automol/graph/base/_07geom.py
+++ b/automol/graph/base/_07geom.py
@@ -147,6 +147,9 @@ def geometry_correct_linear_vinyls(
     :param tol: tolerance of bond angle(s) for determing linearity
     :param excl_keys: Atom keys whose bonds should be excluded (linear atoms)
     """
+    if geo is None:
+        return None
+
     # Align the graph and the geometry keys/indices
     gra, geo, excl_keys, _, idx_dct = align_with_geometry(
         gra, geo, excl_keys, geo_idx_dct

--- a/automol/graph/base/_11stereo.py
+++ b/automol/graph/base/_11stereo.py
@@ -377,6 +377,9 @@ def stereo_corrected_geometry(
         for the reactants or products?
     :returns: a molecular geometry with corrected stereo
     """
+    if geo is None:
+        return None
+
     # Align the graph and the geometry keys/indices
     gra, geo, *_, idx_dct = align_with_geometry(gra, geo, (), geo_idx_dct)
 


### PR DESCRIPTION
Since the procedure could fail at any stage, allow each of these functions to pass along a None value for a retry.