### PR TITLE
Fix: Structureless Reaction objects with dummies

### DIFF
--- a/automol/graph/_2conv.py
+++ b/automol/graph/_2conv.py
@@ -23,6 +23,7 @@ from automol.graph.base import (
     explicit,
     geometry_correct_linear_vinyls,
     geometry_dihedrals_near_value,
+    has_dummy_atoms,
     has_stereo,
     inchi_is_bad,
     is_ts_graph,
@@ -451,6 +452,10 @@ def ts_geometry_from_reactants(
     :return: TS geometry
     :rtype: automol geom data structure
     """
+    assert not has_dummy_atoms(
+        tsg
+    ), f"Cannot convert graph->geom with dummy atoms:\n{tsg}\n{rct_geos}"
+
     # 0. Join geometries for bimolecular reactions, yielding a single starting structure
     ts_geo = ts_join_reactant_geometries(tsg, rct_geos, geo_idx_dct=geo_idx_dct)
 

--- a/automol/reac/_4struc.py
+++ b/automol/reac/_4struc.py
@@ -8,6 +8,7 @@ from automol.reac._0core import (
     apply_zmatrix_conversion,
     mapping,
     product_graphs,
+    without_dummy_atoms,
     product_structures,
     products_conversion_info,
     reactant_graphs,
@@ -67,6 +68,11 @@ def with_structures(
     # 1. Check that we are adding a valid structural type
     if struc_typ not in ("geom", "zmat", None):
         raise ValueError(f"Requesting invalid structure type {struc_typ}")
+
+    # If there are no current structures, remove dummy atoms from the graph to avoid
+    # problems
+    if orig_struc_typ is None:
+        rxn = without_dummy_atoms(rxn)
 
     # If a structure type of `None` was requested, simply update with the structures
     # passed in


### PR DESCRIPTION
For handling old reaction objects without structures