### PR TITLE
Fix: Identify redundant dihedrals for linear fragments

### DIFF
--- a/automol/geom/base/_0core.py
+++ b/automol/geom/base/_0core.py
@@ -4,6 +4,7 @@
 
 import functools
 import itertools
+from collections.abc import Sequence
 from typing import List, Optional
 
 import more_itertools as mit
@@ -406,7 +407,7 @@ def is_diatomic(geo):
     return count(geo) == 2
 
 
-def is_linear(geo, tol=2.0 * phycon.DEG2RAD):
+def is_linear(geo, tol=2.0 * phycon.DEG2RAD, idxs: Sequence[int] | None = None):
     """Determine if the molecular geometry is linear.
 
     :param geo: molecular geometry
@@ -415,6 +416,7 @@ def is_linear(geo, tol=2.0 * phycon.DEG2RAD):
     :type tol: float
     :rtype: bool
     """
+    geo = geo if idxs is None else subgeom(geo, idxs)
 
     ret = True
 

--- a/automol/tests/test_vmat.py
+++ b/automol/tests/test_vmat.py
@@ -83,12 +83,10 @@ def test__atom_indices():
 
 def test__coordinates():
     """ test vmat.angle_names
-        test vmat.dummy_coordinate_names
     """
 
     names = vmat.names(C5H8O_VMA)
     angle_names = vmat.angle_names(C5H8O_VMA)
-    dummy_coord_names = vmat.dummy_coordinate_names(C5H8O_VMA)
 
     assert names == ('R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8', 'R9',
                      'R10', 'R11', 'R12', 'R13', 'R14', 'R15', 'A2', 'A3',
@@ -99,7 +97,6 @@ def test__coordinates():
                            'A9', 'A10', 'A11', 'A12', 'A13', 'A14',
                            'A15', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8',
                            'D9', 'D10', 'D11', 'D12', 'D13', 'D14', 'D15')
-    assert dummy_coord_names == ('R8', 'A8', 'D8', 'R10', 'A10', 'D10')
 
 
 def test__standardize():

--- a/automol/vmat.py
+++ b/automol/vmat.py
@@ -150,6 +150,16 @@ def count(vma: VMatrix) -> int:
     return len(symbols(vma))
 
 
+def keys(vma: VMatrix) -> tuple[int, ...]:
+    """Get the list of z-matrix keys.
+
+    :param vma: V-Matrix
+    :type vma: Automol V-Matrix data structure
+    :return: Number of rows
+    """
+    return tuple(range(count(vma)))
+
+
 def atom_indices(vma: VMatrix, symb: Symbol, match: bool = True) -> tuple[int]:
     """Obtain the indices of a atoms of a particular type in the v-matrix.
 
@@ -458,31 +468,7 @@ def dummy_keys(zma: VMatrix) -> tuple[Key, ...]:
     :param zma: Z-Matrix
     :return: Key to dummy atoms
     """
-    keys = tuple(key for key, sym in enumerate(symbols(zma)) if sym == "X")
-    return keys
-
-
-def dummy_coordinate_names(vma: VMatrix) -> tuple[Name, ...]:
-    """Obtain names of all coordinates associated with dummy atoms
-    defined in the V-Matrix.
-
-    :param vma: V-Matrix
-    :return: Name of coordinates
-    """
-    symbs = symbols(vma)
-    name_mat = numpy.array(name_matrix(vma))
-    dummy_keys = [idx for idx, sym in enumerate(symbs) if not ptab.to_number(sym)]
-    dummy_names = []
-    for dummy_key in dummy_keys:
-        for col_idx in range(3):
-            dummy_name = next(
-                filter(lambda x: x is not None, name_mat[dummy_key:, col_idx])
-            )
-            dummy_names.append(dummy_name)
-
-    dummy_names = tuple(dummy_names)
-
-    return dummy_names
+    return tuple(key for key, sym in enumerate(symbols(zma)) if not ptab.to_number(sym))
 
 
 def dummy_source_dict(
@@ -711,11 +697,11 @@ def string(vma: VMatrix, one_indexed: bool = False) -> str:
 
     def _line_string(row_idx):
         line_str = f"{symbs[row_idx]:<2s} "
-        keys = key_mat[row_idx]
+        keys_ = key_mat[row_idx]
         names_ = name_mat[row_idx]
         line_str += " ".join(
             [
-                f"{keys[col_idx]:>d} {names_[col_idx]:>5s} "
+                f"{keys_[col_idx]:>d} {names_[col_idx]:>5s} "
                 for col_idx in range(min(row_idx, 3))
             ]
         )

--- a/automol/zmat/__init__.py
+++ b/automol/zmat/__init__.py
@@ -17,6 +17,7 @@ from ..vmat import symbols
 from ..vmat import key_matrix
 from ..vmat import name_matrix
 from ..vmat import count
+from ..vmat import keys
 from ..vmat import atom_indices
 from ..vmat import coordinate_key_matrix
 from ..vmat import coordinates
@@ -30,7 +31,7 @@ from ..vmat import distance_names
 from ..vmat import central_angle_names
 from ..vmat import dihedral_angle_names
 from ..vmat import angle_names
-from ..vmat import dummy_coordinate_names
+from ._conv import dummy_coordinate_names
 from ..vmat import standard_names
 from ..vmat import standard_name_matrix
 from ..vmat import distance_coordinate_name
@@ -119,6 +120,7 @@ __all__ = [
     'key_matrix',
     'name_matrix',
     'count',
+    'keys',
     'atom_indices',
     'coordinate_key_matrix',
     'coordinates',

--- a/automol/zmat/base/__init__.py
+++ b/automol/zmat/base/__init__.py
@@ -10,6 +10,7 @@ from ...vmat import symbols
 from ...vmat import key_matrix
 from ...vmat import name_matrix
 from ...vmat import count
+from ...vmat import keys
 from ...vmat import atom_indices
 from ...vmat import coordinate_key_matrix
 from ...vmat import coordinates
@@ -23,7 +24,6 @@ from ...vmat import distance_names
 from ...vmat import central_angle_names
 from ...vmat import dihedral_angle_names
 from ...vmat import angle_names
-from ...vmat import dummy_coordinate_names
 from ...vmat import standard_names
 from ...vmat import standard_name_matrix
 from ...vmat import distance_coordinate_name
@@ -79,6 +79,7 @@ __all__ = [
     'key_matrix',
     'name_matrix',
     'count',
+    'keys',
     'atom_indices',
     'coordinate_key_matrix',
     'coordinates',
@@ -92,7 +93,6 @@ __all__ = [
     'central_angle_names',
     'dihedral_angle_names',
     'angle_names',
-    'dummy_coordinate_names',
     'standard_names',
     'standard_name_matrix',
     # core functions

--- a/automol/zmat/base/_core.py
+++ b/automol/zmat/base/_core.py
@@ -1,5 +1,6 @@
 """ core functionality
 """
+
 import itertools
 
 import numpy


### PR DESCRIPTION
The dihedral angle controlling the relative orientation of two fragments is redundant when one of the fragments is pointing directly at the other along a line. This coordinate should be frozen along with other dummy atom coordinates.