### PR TITLE
Fix: TS diasteriomer expansion w/ reagent matching

### DIFF
--- a/automol/graph/__init__.py
+++ b/automol/graph/__init__.py
@@ -51,8 +51,11 @@ from ._3super_func_group import (
     SuperFunctionalGroup,
     classify_species,
 )
+
+# algorithm functions:
+# # isomorphisms and equivalence
 # submodules:
-from .base import ts, vmat
+from .base import equivalent_without_dummy_atoms, ts, vmat
 
 # # getters
 # # setters
@@ -191,8 +194,6 @@ from .base._00core import (
     zmatrix_conversion_info,
 )
 
-# algorithm functions:
-# # isomorphisms and equivalence
 # # algorithms
 # # branches and groups
 # # rings
@@ -368,45 +369,45 @@ from .base._11stereo import (
 from .base._func_group import (
     FunctionalGroup,
     alcohol_groups,
-    alkoxy_OC_groups,
     aldehyde_groups,
     alkane_sites,
     alkene_sites,
+    alkoxy_OC_groups,
     alkyne_sites,
-    propyne_sites,
     allene_sites,
+    allyl_groups,
+    allyl_groups_lowestspin,
     amide_groups,
+    aromatic_groups,
+    benzene_groups,
+    benzyl_groups,
     bonds_of_order,
     bonds_of_type,
+    c5h5o_groups,
     carboxylic_acid_groups,
     cyclic_ether_groups,
+    cyclopentadiene_groups,
+    cyclopentadienone_groups,
+    cyclopentadienyl_groups,
+    cyclopentenyl_groups,
     ester_groups,
     ether_groups,
+    fulvene_groups,
     functional_group_count_dct,
     functional_group_dct,
+    furan_groups,
     halide_groups,
     hydroperoxy_groups,
     is_hydrocarbon_species,
     is_radical_species,
     ketone_groups,
     methyl_groups,
-    aromatic_groups,
-    benzene_groups,
-    phenyl_groups,
-    benzyl_groups,
-    cyclopentadienyl_groups,
-    cyclopentadiene_groups,
-    cyclopentadienone_groups,
-    fulvene_groups,
-    phenoxy_groups,
-    allyl_groups,
-    allyl_groups_lowestspin,
-    cyclopentenyl_groups,
-    c5h5o_groups,
-    furan_groups,
     neighbors_of_type,
     nitro_groups,
     peroxy_groups,
+    phenoxy_groups,
+    phenyl_groups,
+    propyne_sites,
     radical_dissociation_products,
     radicals_of_type,
     ring_substituents,
@@ -552,6 +553,7 @@ __all__ = [
     "bonds_neighbor_bond_keys",
     # algorithm functions:
     # # isomorphisms and equivalence
+    "equivalent_without_dummy_atoms",
     "isomorphism",
     "isomorphic",
     "unique",

--- a/automol/graph/base/_00core.py
+++ b/automol/graph/base/_00core.py
@@ -3224,3 +3224,19 @@ def invert_atom_stereo_parities(gra):
     )
     gra = set_atom_stereo_parities(gra, atm_par_dct)
     return gra
+
+
+def equivalent_without_dummy_atoms(
+    gra1: object, gra2: object, shift_keys: bool = True
+) -> bool:
+    """Check whether two graphs are equivalent without dummy atoms.
+
+    :param gra1: First graph
+    :param gra2: Second graph
+    :param shift_keys: Shift the keys before comparing?
+    :return: `True` if they are, `False` if they aren't
+    """
+    gra1, gra2 = map(without_dummy_atoms, (gra1, gra2))
+    if shift_keys:
+        gra1, gra2 = map(standard_keys, (gra1, gra2))
+    return gra1 == gra2

--- a/automol/graph/base/__init__.py
+++ b/automol/graph/base/__init__.py
@@ -170,6 +170,7 @@ from ._00core import bonds_neighbor_bond_keys
 
 # algorithm functions:
 # # isomorphisms and equivalence
+from ._00core import equivalent_without_dummy_atoms
 from ._02algo import isomorphism
 from ._02algo import isomorphic
 from ._02algo import unique
@@ -532,6 +533,7 @@ __all__ = [
     "bonds_neighbor_bond_keys",
     # algorithm functions:
     # # isomorphisms and equivalence
+    "equivalent_without_dummy_atoms",
     "isomorphism",
     "isomorphic",
     "unique",

--- a/automol/reac/_3find.py
+++ b/automol/reac/_3find.py
@@ -31,12 +31,13 @@ from .. import form, graph
 from ..const import ReactionClass
 from ..graph import ts
 from ._0core import (
+    Reaction,
     from_forward_reverse,
     reverse_without_recalculating,
     unique,
 )
 from ._1util import assert_is_valid_reagent_graph_list
-from ._2stereo import expand_stereo_to_match_reagents
+from ._2stereo import expand_stereo
 
 
 def trivial(rct_gras, prd_gras):
@@ -726,15 +727,17 @@ def _is_graph(gra):
     return False
 
 
-def find(rct_gras, prd_gras, stereo=False):
-    """find all reactions consistent with these reactants and products
+def find(
+    rct_gras, prd_gras, stereo: bool = False, enant: bool = True, strained: bool = True
+) -> tuple[Reaction, ...]:
+    """Find all reactions consistent with these reactants and products.
 
-    :param rct_gras: graphs for the reactants without overlapping keys
-    :param prd_gras: graphs for the products without overlapping keys
+    :param rct_gras: Graphs for the reactants
+    :param prd_gras: Graphs for the products
     :param stereo: Find stereo-specified reaction objects?
-    :type stereo: bool
-    :returns: a list of Reaction objects
-    :rtype: tuple[Reaction]
+    :param enant: If expanding stereo, include enantiomers?
+    :param strained: If expanding stereo, include strained stereoisomers?
+    :returns: The reaction Reaction objects
     """
     if _is_graph(rct_gras):
         assert _is_graph(prd_gras)
@@ -780,8 +783,12 @@ def find(rct_gras, prd_gras, stereo=False):
             if not stereo:
                 all_rxns.append(rxn)
             else:
-                srxns = expand_stereo_to_match_reagents(
-                    rxn, rct_gras0, prd_gras0, shift_keys=True
+                srxns = expand_stereo(
+                    rxn,
+                    enant=enant,
+                    strained=strained,
+                    rct_gras=rct_gras0,
+                    prd_gras=prd_gras0,
                 )
                 all_rxns.extend(srxns)
     # Check for uniqueness *after* stereochemistry is assigned

--- a/automol/reac/__init__.py
+++ b/automol/reac/__init__.py
@@ -30,6 +30,7 @@ from ._0core import reverse_without_recalculating
 from ._0core import mapping
 from ._0core import reactant_mappings
 from ._0core import product_mappings
+from ._0core import reagent_mappings
 from ._0core import reactant_graphs
 from ._0core import product_graphs
 from ._0core import reactants_graph
@@ -44,7 +45,6 @@ from ._0core import is_radical_radical
 from ._0core import unique
 # stereo-specific reactions
 from ._2stereo import expand_stereo
-from ._2stereo import expand_stereo_to_match_reagents
 from ._2stereo import reflect
 # finders
 from ._3find import trivial
@@ -141,6 +141,7 @@ __all__ = [
     'mapping',
     'reactant_mappings',
     'product_mappings',
+    'reagent_mappings',
     'reactant_graphs',
     'product_graphs',
     'reactants_graph',
@@ -155,7 +156,6 @@ __all__ = [
     'unique',
     # stereo-specific reactions
     'expand_stereo',
-    'expand_stereo_to_match_reagents',
     'reflect',
     # finders
     'trivial',

--- a/automol/tests/test_reac.py
+++ b/automol/tests/test_reac.py
@@ -72,41 +72,54 @@ def test__reactant_graphs():
     _test(["CO", "C[CH2]"], ["CCC", "[OH]"])
 
 
-def test__expand_stereo():
-    """Test reac.expand_stereo_for_reaction"""
+@pytest.mark.parametrize(
+    "rsmi,psmi,nexp1,nexp2",
+    [
+        ("FC=CF.[OH]", "F[CH]C(O)F", 2, 4),
+    ],
+)
+def test__expand_stereo(rsmi: str, psmi: str, nexp1: int, nexp2: int):
+    """Test reac.expand_stereo_for_reaction."""
+    print("Testing expand_stereo_for_reaction()")
+    print(f"{rsmi}>>{psmi}")
+    rct_smis = rsmi.split(".")
+    prd_smis = psmi.split(".")
+    rct_gras0 = tuple(map(smiles.graph, rct_smis))
+    prd_gras0 = tuple(map(smiles.graph, prd_smis))
+    rxn = reac.find(rct_gras0, prd_gras0, stereo=False)[0]
+    srxns = reac.expand_stereo(rxn, enant=False)
+    assert len(srxns) == nexp1
+    srxns = reac.expand_stereo(rxn, enant=True)
+    assert len(srxns) == nexp2
 
-    def _test(rct_smis, prd_smis, nexp1, nexp2):
-        print("Testing expand_stereo()")
-        print(f"{'.'.join(rct_smis)}>>{'.'.join(prd_smis)}")
-        rct_gras0 = tuple(map(smiles.graph, rct_smis))
-        prd_gras0 = tuple(map(smiles.graph, prd_smis))
-        rxn = reac.find(rct_gras0, prd_gras0, stereo=False)[0]
-        srxns = reac.expand_stereo(rxn, enant=False)
-        assert len(srxns) == nexp1
-        srxns = reac.expand_stereo(rxn, enant=True)
-        assert len(srxns) == nexp2
 
-    _test(["FC=CF", "[OH]"], ["F[CH]C(O)F"], 2, 4)
+@pytest.mark.parametrize(
+    "rsmi,psmi,enant,count",
+    [
+        ("F/C=C/F.[OH]", "F[CH][C@H](O)F", False, 1),
+        ("CCOCC.[OH]", "C[CH]OCC.O", True, 2),
+        ("CCOCC.[OH]", "C[CH]OCC.O", False, 1),
+        ("CCO[C@H](C)CC.[OH]", "C[CH]O[C@H](C)CC.O", True, 2),
+        ("CCO[C@H](C)CC.[OH]", "C[CH]O[C@H](C)CC.O", False, 2),
+    ],
+)
+def test__expand_stereo_for_reaction(rsmi: str, psmi: str, enant: bool, count: int):
+    """Test reac.expand_stereo_for_reaction."""
+    print("Testing expand_stereo_for_reaction()")
+    print(f"{rsmi}>>{psmi}")
+    rct_smis = rsmi.split(".")
+    prd_smis = psmi.split(".")
+    rct_gras0 = tuple(map(smiles.graph, rct_smis))
+    prd_gras0 = tuple(map(smiles.graph, prd_smis))
+    rxn = reac.find(rct_gras0, prd_gras0, stereo=False)[0]
+    srxns = reac.expand_stereo(rxn, enant=enant, rct_gras=rct_gras0, prd_gras=prd_gras0)
+    assert len(srxns) == count
 
-
-def test__expand_stereo_for_reaction():
-    """Test reac.expand_stereo_for_reaction"""
-
-    def _test(rct_smis, prd_smis):
-        print("Testing expand_stereo_for_reaction()")
-        print(f"{'.'.join(rct_smis)}>>{'.'.join(prd_smis)}")
-        rct_gras0 = tuple(map(smiles.graph, rct_smis))
-        prd_gras0 = tuple(map(smiles.graph, prd_smis))
-        rxn = reac.find(rct_gras0, prd_gras0, stereo=False)[0]
-        srxns = reac.expand_stereo_to_match_reagents(rxn, rct_gras0, prd_gras0)
-        assert len(srxns) == 1
-        (srxn,) = srxns
+    for srxn in srxns:
         rct_gras1 = reac.reactant_graphs(srxn, shift_keys=False)
         prd_gras1 = reac.product_graphs(srxn, shift_keys=False)
         assert rct_gras1 == rct_gras0
         assert prd_gras1 == prd_gras0
-
-    _test(["F/C=C/F", "[OH]"], ["F[CH][C@H](O)F"])
 
 
 def test__from_old_string():
@@ -516,5 +529,13 @@ if __name__ == "__main__":
     # test__end_to_end("CCCO[O]", "[CH2]CCOO")
     # test__end_to_end("C[C]1O[C@H]1COO", r"C/C([O])=C\COO")
     # test__end_to_end("CC1[C](O1)COO", "CC1C2(O1)CO2.[OH]")
+    # test__end_to_end("CC1[C](O1)COO", "CC1C2(O1)CO2.[OH]")
+    # test__end_to_end("CC1[C](OC1)CCOO", "CC1C2(OC1)CCO2.[OH]")
     # test__canonical_enantiomer()
-    test__from_geometries("C5H7O", C5H7O_RGEOS, C5H7O_PGEOS, 1)
+    # test__from_geometries("C5H7O", C5H7O_RGEOS, C5H7O_PGEOS, 1)
+    # test__expand_stereo_for_reaction("F/C=C/F.[OH]", "F[CH][C@H](O)F", False, 1)
+    # test__expand_stereo_for_reaction("CCOCC.[OH]", "C[CH]OCC.O", True, 2)
+    # test__expand_stereo_for_reaction("CCOCC.[OH]", "C[CH]OCC.O", False, 1)
+    # test__expand_stereo_for_reaction("CCO[C@H](C)CC.[OH]", "C[CH]O[C@H](C)CC.O", True, 2)
+    # test__expand_stereo_for_reaction("CCO[C@H](C)CC.[OH]", "C[CH]O[C@H](C)CC.O", False, 2)
+    test__expand_stereo("FC=CF.[OH]", "F[CH]C(O)F", 2, 4)


### PR DESCRIPTION
Previously, this was not possible because the expansion was filtered before matching to the reagents. Now, we match to reagents first and filter after.

The reactant and product graphs are passed directly to the expand_stereo function, so there is no longer a need for a separate `expand_stereo_to_match_reagents` function.