### PR TITLE
Fix: Stereo handling for double bridgehead case

### DIFF
--- a/automol/graph/base/_08canon.py
+++ b/automol/graph/base/_08canon.py
@@ -261,7 +261,9 @@ def ts_direction_representation(tsg, pri_dct: dict):
         sorted(sorted(map(pri_dct.get, k)) for k in frm_keys),
         sorted(sorted(map(pri_dct.get, k)) for k in brk_keys),
     )
-    rep = (rxn_rep1, rxn_rep2)
+    # Rep value 3: Stereo assignment
+    ste_rep = stereo_assignment_representation(tsg, pri_dct)
+    rep = (rxn_rep1, rxn_rep2, ste_rep)
     return rep
 
 


### PR DESCRIPTION
The case is:
```
 C1CC2[CH]C1O2 => [CH]1CC2CC1O2
 ^  *  ^  *        ^    * ^*
 [* marks the first pair of bridgehead stereo atoms]
 [^ marks the first pair of bridgehead stereo atoms]
```
This case challenges the current stereo-reversibility implementation.

The problem: The internal H transfer switches breaking and forming bonds in the TS graph. The canonical direction comparison was returning `None` for this process because the representations of the forward and reverse direction were identical. This has been partially fixed by adding a stereo parity component back into the representation, but it seems there is still something wrong (possibly some cases are still yielding identical representations -- I haven't yet investigated).