### PR TITLE
Fix: Mode normalization / display amplitude

### DIFF
--- a/automol/extern/py3dmol_.py
+++ b/automol/extern/py3dmol_.py
@@ -33,7 +33,7 @@ def view_molecule_from_xyz(
     if view is None:
         view = create_view(image_size=image_size)
 
-    options = {"vibrate": {"frames": 10, "amplitude": 3}} if vib else {}
+    options = {"vibrate": {"frames": 10, "amplitude": 1}} if vib else {}
 
     view.addModel(xyz_str, "xyz", options)
     view.setStyle({"stick": {}, "sphere": {"radius": 0.3}})

--- a/automol/geom/_2vib.py
+++ b/automol/geom/_2vib.py
@@ -71,6 +71,7 @@ def vibrational_analysis(
     #       Qmw = PI (see above)    Q = Qmw / mw_vec
     norm_coos_mw = numpy.dot(proj, eig_vecs) / mw_vec[:, numpy.newaxis]
     norm_coos = norm_coos_mw / mw_vec[:, numpy.newaxis]
+    norm_coos = norm_coos / numpy.linalg.norm(norm_coos, axis=0)
     if not wavenum:
         return eig_vals, norm_coos
 


### PR DESCRIPTION
Re-normalizes modes after un-mass-weighting for display purposes. Otherwise, hydrogen motions display with an exaggerated amplitude relative to heavy-atom motions. Also, dials the display amplitude back down to 1 now that the heavy-atom modes are more visible.