### PR TITLE
Updated xarray wrapper Functions

### DIFF
--- a/autoreact/ktp_xarray/xarray_wrappers.py
+++ b/autoreact/ktp_xarray/xarray_wrappers.py
@@ -13,7 +13,7 @@ RateConstant = xarray.DataArray
 def from_data(
     temps: Sequence[Number], press: Sequence[Number], rates: Sequence[Sequence[Number]]
 ) -> RateConstant:
-    """Construct a KTP DataArray from data.."""
+    """Construct a KTP DataArray from data."""
     data = [list(map(float, kT)) for kT in rates]
     coords = {
         "pres": list(map(float, press)),
@@ -22,20 +22,27 @@ def from_data(
     ktp = xarray.DataArray(data=data, coords=coords)
     return ktp
 
+def make_empty_dataarray(temps: Sequence[Number], press: Sequence[Number]
+) -> RateConstant:
+    """Construct a DataArray filled with numpy.nan objects."""
+    empty_ndarray = numpy.full((len(press), len(temps)), numpy.nan)
+    ktp = from_data(temps, press, empty_ndarray)
+    return ktp
+
 
 # Getters
 def get_pressures(ktp: RateConstant) -> numpy.ndarray:
-    """Get the pressure values.."""
+    """Get the pressure values."""
     return ktp.pres.data
 
 
 def get_temperatures(ktp: RateConstant) -> numpy.ndarray:
-    """Get the temperature values.."""
+    """Get the temperature values."""
     return ktp.temp.data
 
 
 def get_values(ktp: RateConstant) -> numpy.ndarray:
-    """Get the KTP values.."""
+    """Get the KTP values."""
     return ktp.values
 
 
@@ -59,7 +66,7 @@ def get_ipslice(ktp: RateConstant, ip: int) -> numpy.ndarray:
     return ktp.isel(pres=ip)
 
 
-def get_itslice(ktp: RateConstant, it: int):
+def get_itslice(ktp: RateConstant, it: int) -> numpy.ndarray:
     """Get a slice at a selected temperature index."""
     return ktp.isel(temp=it)
 
@@ -72,9 +79,14 @@ def set_rates(
     ktp.loc[{"pres": pres, "temp": temp}] = rates
     return ktp
 
+def set_rates_pslice(
+    ktp: RateConstant, rates: Sequence[Sequence[Number]], pres: Number):
+    """Set the KTP values at a specific pressure slice."""
+    ktp.loc[{"pres": pres}] = rates
+    return ktp
+
 
 # Translators
-
 
 def dict_from_xarray(xarray_in: RateConstant) -> dict:
     """Turn an xarray into a ktp_dct."""

--- a/autoreact/ktp_xarray/xarray_wrappers_test.py
+++ b/autoreact/ktp_xarray/xarray_wrappers_test.py
@@ -16,15 +16,23 @@ Ktp_dct = {
 }
 print(Ktp)
 
+def test_make_empty_dataarray():
+    """Test the make_empty_dataarray function."""
+    print("* Testing the make_empty_dataarray function.")
+    empty = xarray_wrappers.make_empty_dataarray(Temps, Press)
+    print(empty)
+
 
 def test_get_temperatures():
     """Test the get_temperatures function."""
+    print("* Testing the get_temperatures function.")
     temp = xarray_wrappers.get_temperatures(Ktp)
     print(temp)
 
 
 def test_get_pressures():
     """Test the get_pressures function."""
+    print("* Testing the get_pressures function.")
     pres = xarray_wrappers.get_pressures(Ktp)
     print(f"pres = {pres}")
     print(type(pres))
@@ -32,6 +40,7 @@ def test_get_pressures():
 
 def test_get_values():
     """Test the get_values function."""
+    print("* Testing the get_values function.")
     vals = xarray_wrappers.get_values(Ktp)
     print(f"vals = {vals}")
     print(type(vals))
@@ -39,6 +48,7 @@ def test_get_values():
 
 def test_get_pslice():
     """Test the get_pslice function."""
+    print("* Testing the get_pslice function.")
     pslice = xarray_wrappers.get_pslice(Ktp, numpy.inf)
     print(f"pslice = {pslice}")
     print(type(pslice))
@@ -46,36 +56,50 @@ def test_get_pslice():
 
 def test_get_tslice():
     """Test the get_tslice function."""
+    print("* Testing the get_tslice function.")
     tslice = xarray_wrappers.get_tslice(Ktp, 1500)
     print(tslice)
 
 
 def test_get_spec_vals():
     """Test the get_spec_values function."""
+    print("* Testing the get_spec_values function.")
     vals = xarray_wrappers.get_spec_vals(Ktp, 1500, 1)
     print(vals)
 
 
 def test_get_ipslice():
     """Test the get_ipslice function."""
+    print("* Testing the get_ipslice function.")
     ipslice = xarray_wrappers.get_ipslice(Ktp, 0)
     print(ipslice)
 
 
 def test_get_itslice():
     """Test the get_itslice function."""
+    print("* Testing the get_itslice function.")
     itslice = xarray_wrappers.get_itslice(Ktp, 0)
     print(itslice)
 
 
 def test_set_rates():
     """Test the set_rates function."""
-    new_rates = xarray_wrappers.set_rates(Ktp, numpy.nan, 10, 2000)
-    print(new_rates)
+    print("* Testing the set_rates function.")
+    new_rate = numpy.nan
+    updated_rates = xarray_wrappers.set_rates(Ktp, new_rate, 10, 2000)
+    print(updated_rates)
+
+def test_set_rates_pslice():
+    """* Testing the set_rates_pslice function."""
+    print("* Testing the set_rates_pslice function.")
+    new_rates = [1.e+13, 1.e+14, 1.e+15, 1.e+16]
+    updated_rates = xarray_wrappers.set_rates_pslice(Ktp, new_rates, 10)
+    print(updated_rates)
 
 
 def test_dict_from_xarray():
-    """Test the ktp_to_xarray function."""
+    """* Test the ktp_to_xarray function."""
+    print("Testing the ktp_to_xarray function.")
     ktp_dct = xarray_wrappers.dict_from_xarray(Ktp)
     print(ktp_dct)
 
@@ -86,14 +110,16 @@ def test_dict_from_xarray():
 #    print(xarray)
 
 
-# test_get_pressures()
-# test_get_temperatures()
-# test_get_values()
+test_make_empty_dataarray()
+test_get_pressures()
+test_get_temperatures()
+test_get_values()
 test_get_pslice()
-# test_get_tslice()
-# test_get_spec_vals()
-# test_get_ipslice()
-# test_get_itslice()
-# test_set_rates()
-# test_dict_from_xarray()
+test_get_tslice()
+test_get_spec_vals()
+test_get_ipslice()
+test_get_itslice()
+test_set_rates()
+test_set_rates_pslice()
+test_dict_from_xarray()
 # test_xarray_from_dict()


### PR DESCRIPTION
A few updated features were requested in xarray_wrappers.py. They are as follows:

make_empty_dataarray: Makes a DataArray object that is filled with only numpy.nan objects. This feature will allow for easy creation of unfilled DataArrays of a desired size.

set_rates_pslice: Sets the kts at a given pressure slice. This will allow for easy updating of pressure slices for features such as filtering.