### PR TITLE
Correct missing factor of pi in Z and alpha

### DIFF
--- a/src/automol/etrans/_fxn.py
+++ b/src/automol/etrans/_fxn.py
@@ -11,8 +11,10 @@ def troe_lj_collision_frequency(eps, sig, red_mass, temp):
     """ Collision Frequency formula from Troe that uses
         Lennard-Jones epsilons and sigma parameters
 
-        Z = sqrt( (8*kB*T)/(pi*mu) ) * sig^2 * omega
+        Z = pi * sqrt( (8*kB*T)/(pi*mu) ) * sig^2 * omega
         omega = [ 0.7 + 0.5 log10( (kB*T)/eps ) ]^-1
+
+        See Eq. 12 from Jasper, J. Phys. Chem. A 2009, 113, 19, 5612-5619
 
         :param eps: Target+Bath Lennard-Jones epsilon value (in hart)
         :type eps: float
@@ -35,7 +37,7 @@ def troe_lj_collision_frequency(eps, sig, red_mass, temp):
     kbt = phycon.KB * temp
 
     # Prefactor term with physical constants and masses
-    pref1 = numpy.sqrt((8.0 * kbt) / (numpy.pi * red_mass))
+    pref1 = numpy.pi * numpy.sqrt((8.0 * kbt) / (numpy.pi * red_mass))
 
     # Omega integral
     omega_s = (0.7 + 0.52 * (numpy.log10(kbt / eps)))**(-1)

--- a/src/automol/tests/test_etrans.py
+++ b/src/automol/tests/test_etrans.py
@@ -167,7 +167,7 @@ def test__estimate():
     # Build the alpha parameters
     edown_alpha, edown_n = automol.etrans.estimate.alpha(
         n_eff, eps, sig, tgt_mass, bath_mass, collider_set)
-    ref_edown_alpha = 457.24552400133837
+    ref_edown_alpha = 457.24552400133837 / numpy.pi
     ref_edown_n = 0.70088400006973
     assert numpy.isclose(edown_alpha, ref_edown_alpha)
     assert numpy.isclose(edown_n, ref_edown_n)


### PR DESCRIPTION
This was confirmed against the spreadsheet Z and Z*alpha values from Ahren's 2020 paper.